### PR TITLE
fix(fabric-core): sort imports by resolved relative path, not absolute path

### DIFF
--- a/.changeset/sort-imports-by-relative-path.md
+++ b/.changeset/sort-imports-by-relative-path.md
@@ -1,0 +1,5 @@
+---
+"@kubb/fabric-core": patch
+---
+
+Sort combined imports by their resolved relative path instead of the raw absolute `path`. When `root` is set, the emitted specifier is `getRelativePath(root, path)`, so sorting on the absolute `path` made the import order depend on where the project lives on disk — producing different orderings for identical output (e.g. a CLI cwd vs a bundler root). Sorting on the resolved relative path keeps the generated import order deterministic across environments.

--- a/packages/fabric-core/src/createFile.test.ts
+++ b/packages/fabric-core/src/createFile.test.ts
@@ -393,6 +393,23 @@ describe('createFile', () => {
     ])
   })
 
+  it('should sort imports by their resolved relative path, not the absolute path', () => {
+    // When `root` is set the import specifier is `getRelativePath(root, path)`.
+    // Sorting must use that relative path so the order is stable regardless of
+    // the absolute location on disk (e.g. a CLI cwd vs a bundler root).
+    // Here the absolute-`path` order ([Y, X]) differs from the relative order
+    // ([X, Y]); only the relative sort is deterministic across environments.
+    const root = '/a/b/c/file.ts'
+    const imports: Array<KubbFile.Import> = [
+      { path: '/a/x.ts', name: 'X', root }, // -> ../../x.ts
+      { path: '/a/b/y.ts', name: 'Y', root }, // -> ../y.ts
+    ]
+
+    const result = combineImports(imports, [], 'const v = X + Y;')
+
+    expect(result.map((i) => i.name)).toEqual(['X', 'Y'])
+  })
+
   it('should keep both type-only and non-type-only exports/imports with same path and name', () => {
     // When exports/imports have the same path and name but different isTypeOnly values,
     // both should be preserved because they serve different purposes:

--- a/packages/fabric-core/src/createFile.ts
+++ b/packages/fabric-core/src/createFile.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import path from 'node:path'
 import { sortBy, uniqueBy } from 'remeda'
 import type * as KubbFile from './FabricFile.ts'
+import { getRelativePath } from './utils/getRelativePath.ts'
 import { trimExtName } from './utils/trimExtName.ts'
 
 export function combineSources(sources: Array<KubbFile.Source>): Array<KubbFile.Source> {
@@ -116,7 +117,12 @@ export function combineImports(imports: Array<KubbFile.Import>, exports: Array<K
     imports,
     (v) => Array.isArray(v.name),
     (v) => !v.isTypeOnly,
-    (v) => v.path,
+    // Sort by the path as it will actually be emitted. When `root` is set the
+    // specifier is `getRelativePath(root, path)`, so sorting on the raw absolute
+    // `path` makes the order depend on where the project lives on disk (e.g. a
+    // CLI cwd vs a bundler root), producing different orderings for identical
+    // output. Sorting on the resolved relative path keeps it deterministic.
+    (v) => (v.root ? getRelativePath(v.root, v.path) : v.path),
     (v) => !!v.name,
     // join with null byte — can't appear in identifiers, so avoids collisions between e.g. ['a','b'] and ['a,b']
     (v) => (Array.isArray(v.name) ? [...v.name].sort().join('\0') : (v.name ?? '')),


### PR DESCRIPTION
## 🎯 Changes

`combineImports` sorted by the raw absolute `path`. When `root` is set, the import specifier is actually emitted as `getRelativePath(root, path)`, so sorting on the absolute `path` makes the import order depend on **where the project lives on disk** — e.g. a CLI run (one cwd) versus a bundler (`unplugin-kubb`, a different absolute root) generate the *same* files but with a *different* import order.

This changes the `combineImports` sort key to sort on the resolved relative path when `root` is set, falling back to `path` otherwise, so the generated import order is deterministic across environments.

```diff
  const sorted = sortBy(
    imports,
    (v) => Array.isArray(v.name),
    (v) => !v.isTypeOnly,
-   (v) => v.path,
+   (v) => (v.root ? getRelativePath(v.root, v.path) : v.path),
    (v) => !!v.name,
    ...
  )
```

`combineExports` is intentionally left unchanged: `KubbFile.Export` has no `root` field, so there is no relative path to sort on.

A unit test is added that fails on the old behaviour (absolute order `[Y, X]`) and passes with the fix (relative order `[X, Y]`). Existing tests don't set `root`, so behaviour there is unchanged.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/fabric/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
