### PR TITLE
fix: bump ws to 8.21.2 in @kubb/react-fabric to fix security vulnerabilities

### DIFF
--- a/.changeset/bump-ws-dependency.md
+++ b/.changeset/bump-ws-dependency.md
@@ -1,0 +1,5 @@
+---
+"@kubb/react-fabric": patch
+---
+
+Bump `ws` to 8.21.2 to fix two high severity vulnerabilities (uninitialized memory disclosure and memory exhaustion DoS)

--- a/packages/react-fabric/package.json
+++ b/packages/react-fabric/package.json
@@ -119,7 +119,7 @@
     "@kubb/fabric-core": "workspace:*",
     "react-devtools-core": "6.1.5",
     "remeda": "catalog:",
-    "ws": "8.18.0"
+    "ws": "8.21.2"
   },
   "devDependencies": {
     "@types/react": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,8 +155,8 @@ importers:
         specifier: 'catalog:'
         version: 2.33.6
       ws:
-        specifier: 8.18.0
-        version: 8.18.0
+        specifier: 8.21.2
+        version: 8.21.2
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -2061,6 +2061,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -2260,8 +2261,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+  ws@8.21.2:
+    resolution: {integrity: sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4232,7 +4233,7 @@ snapshots:
 
   ws@7.5.10: {}
 
-  ws@8.18.0: {}
+  ws@8.21.2: {}
 
   xdg-basedir@5.1.0: {}
 


### PR DESCRIPTION
## 🎯 Changes

`npm audit` reported two high severity vulnerabilities in `ws@8.18.0`, a direct dependency of `@kubb/react-fabric`:

1. Uninitialized memory disclosure — [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) (patched in `8.20.1`)
2. Memory exhaustion DoS from tiny fragments and data chunks — [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p) (patched in `8.21.0`)

The issue requested `8.20.2`, but that version was never published to npm and wouldn't cover the second advisory anyway (it needs `8.21.0`+). This bumps `ws` to `8.21.2`, the latest release, which covers both advisories, and regenerates `pnpm-lock.yaml` accordingly.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/fabric/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

Fixes #194


---
_Generated by [Claude Code](https://claude.ai/code/session_01929uvDzVAedY7uf5MgRzhd)_