### PR TITLE
chore: add context7.json separating Fabric from Kubb

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
+  "url": "https://context7.com/kubb-labs/fabric",
+  "public_key": "pk_E3UkJR9X5FvhME9wB1sCS",
   "projectTitle": "Kubb Fabric",
   "description": "Language-agnostic toolkit for generating code and files with JSX and TypeScript. Fabric is the engine you build a generator on, not an OpenAPI generator itself.",
   "folders": ["docs", "packages"],

--- a/context7.json
+++ b/context7.json
@@ -3,7 +3,7 @@
   "url": "https://context7.com/kubb-labs/fabric",
   "public_key": "pk_E3UkJR9X5FvhME9wB1sCS",
   "projectTitle": "Kubb Fabric",
-  "description": "Language-agnostic toolkit for generating code and files with JSX and TypeScript. Fabric is the engine you build a generator on, not an OpenAPI generator itself.",
+  "description": "Language-agnostic toolkit for generating code and files using JSX and TypeScript. Fabric is the engine you build a generator on, not an OpenAPI generator itself.",
   "folders": ["docs", "packages"],
   "excludeFiles": ["AGENTS.md", "CHANGELOG.md", "changelog.md", "CODE_OF_CONDUCT.md", "SECURITY.md"],
   "rules": [

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Kubb Fabric",
+  "description": "Language-agnostic toolkit for generating code and files with JSX and TypeScript. Fabric is the engine you build a generator on, not an OpenAPI generator itself.",
+  "folders": ["docs", "packages"],
+  "excludeFiles": ["AGENTS.md", "CHANGELOG.md", "changelog.md", "CODE_OF_CONDUCT.md", "SECURITY.md"],
+  "rules": [
+    "Fabric and Kubb are separate projects. Fabric generates files from JSX and reads no OpenAPI spec. To generate TypeScript types, clients, hooks or schemas from an OpenAPI spec, use Kubb instead: https://kubb.dev, indexed on Context7 as /kubb-labs/docs. Reach for Fabric when you are building the generator itself.",
+    "The packages are `@kubb/fabric-core` and `@kubb/react-fabric`. Neither is a Kubb plugin, and `@kubb/plugin-*` packages do not run on Fabric.",
+    "Fabric runs on Node.js 20+ and Bun.",
+    "Plugins are `fsPlugin`, `barrelPlugin`, `loggerPlugin` and `reactPlugin`, and parsers cover TypeScript, TSX and custom formats."
+  ]
+}


### PR DESCRIPTION
## 🎯 Changes

`/kubb-labs/fabric` currently carries 834 snippets on Context7, four times the official `/kubb-labs/kubb` entry, so it surfaces prominently for anything matching "kubb". Its own docs make the overlap worse: `docs/getting-started/introduction.md` lists "Creating API client libraries from OpenAPI specs" and "Generate TypeScript types, API clients, or SDK code from OpenAPI/GraphQL schemas" as use cases. An agent asked to generate types from an OpenAPI spec can plausibly land here and start writing JSX generators by hand instead of using Kubb.

This adds a `context7.json` that scopes the parse and routes by task rather than by name:

- `folders: ["docs", "packages"]` covers the 47 documentation pages and the two package READMEs. Context7 skips raw source when documentation is present.
- `excludeFiles` drops the changelogs (both casings — `docs/changelog.md` and the per-package `CHANGELOG.md`) plus the agent, conduct and security files, which are always-included root markdown otherwise.
- The first rule states plainly that Fabric and Kubb are separate projects, that Fabric reads no OpenAPI spec, and that OpenAPI work belongs on kubb.dev (`/kubb-labs/docs`) — while pointing at Fabric for building a generator, which is the case where landing here is correct.
- The remaining rules pin facts an index can get wrong: the package names are `@kubb/fabric-core` and `@kubb/react-fabric`, neither is a Kubb plugin, `@kubb/plugin-*` does not run on Fabric, and the runtime floor is Node.js 20+ or Bun.

The library has since been claimed, so the file also carries the Context7 `url` and `public_key` alongside the parse config, matching the kubb, plugins and docs repos.

Companion PRs: kubb-labs/docs#184, kubb-labs/kubb#3911, kubb-labs/plugins#770.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/fabric/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

Not applicable: the file is a root config for an external service and touches no source.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).