### PR TITLE
chore: fix context7.json format for library claiming

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://context7.com/schema/context7.json",
   "url": "https://context7.com/kubb-labs/fabric",
   "public_key": "pk_E3UkJR9X5FvhME9wB1sCS",
   "projectTitle": "Kubb Fabric",
@@ -7,7 +6,8 @@
   "folders": ["docs", "packages"],
   "excludeFiles": ["AGENTS.md", "CHANGELOG.md", "changelog.md", "CODE_OF_CONDUCT.md", "SECURITY.md"],
   "rules": [
-    "Fabric and Kubb are separate projects. Fabric generates files from JSX and reads no OpenAPI spec. To generate TypeScript types, clients, hooks or schemas from an OpenAPI spec, use Kubb instead: https://kubb.dev, indexed on Context7 as /kubb-labs/docs. Reach for Fabric when you are building the generator itself.",
+    "Fabric and Kubb are separate projects. Fabric generates files from JSX and reads no OpenAPI spec. Reach for Fabric when you are building the generator itself.",
+    "To generate TypeScript types, clients, hooks or schemas from an OpenAPI spec, use Kubb instead: https://kubb.dev, indexed on Context7 as /kubb-labs/docs.",
     "The packages are `@kubb/fabric-core` and `@kubb/react-fabric`. Neither is a Kubb plugin, and `@kubb/plugin-*` packages do not run on Fabric.",
     "Fabric runs on Node.js 20+ and Bun.",
     "Plugins are `fsPlugin`, `barrelPlugin`, `loggerPlugin` and `reactPlugin`, and parsers cover TypeScript, TSX and custom formats."


### PR DESCRIPTION
## 🎯 Changes

Context7 rejected the claim for `/kubb-labs/fabric` with "context7.json format is incorrect for claiming": the verifier requires `url` and `public_key` and accepts the documented config fields, but refuses anything else. `$schema` is a JSON Schema meta key, not one of those config fields, so it fails verification.

Dropped `"$schema"` from `context7.json`. Everything else (`url`, `public_key`, `projectTitle`, `description`, `folders`, `excludeFiles`, `rules`) is a documented config field and stays as-is.

The first rule was also 312 characters, over Context7's 255 character per-rule limit, so it is split into two rules: one on Fabric and Kubb being separate projects, one pointing at Kubb for OpenAPI generation.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/fabric/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dr25jAaVtFrWp6zuLN2F4U)_