### PR TITLE
chore: restore the context7.json parsing config

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,15 +1,4 @@
 {
   "url": "https://context7.com/kubb-labs/fabric",
-  "public_key": "pk_E3UkJR9X5FvhME9wB1sCS",
-  "projectTitle": "Kubb Fabric",
-  "description": "Language-agnostic toolkit for generating code and files using JSX and TypeScript. Fabric is the engine you build a generator on, not an OpenAPI generator itself.",
-  "folders": ["docs", "packages"],
-  "excludeFiles": ["AGENTS.md", "CHANGELOG.md", "changelog.md", "CODE_OF_CONDUCT.md", "SECURITY.md"],
-  "rules": [
-    "Fabric and Kubb are separate projects. Fabric generates files from JSX and reads no OpenAPI spec. Reach for Fabric when you are building the generator itself.",
-    "To generate TypeScript types, clients, hooks or schemas from an OpenAPI spec, use Kubb instead: https://kubb.dev, indexed on Context7 as /kubb-labs/docs.",
-    "The packages are `@kubb/fabric-core` and `@kubb/react-fabric`. Neither is a Kubb plugin, and `@kubb/plugin-*` packages do not run on Fabric.",
-    "Fabric runs on Node.js 20+ and Bun.",
-    "Plugins are `fsPlugin`, `barrelPlugin`, `loggerPlugin` and `reactPlugin`, and parsers cover TypeScript, TSX and custom formats."
-  ]
+  "public_key": "pk_E3UkJR9X5FvhME9wB1sCS"
 }

--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,16 @@
 {
+  "$schema": "https://context7.com/schema/context7.json",
   "url": "https://context7.com/kubb-labs/fabric",
-  "public_key": "pk_E3UkJR9X5FvhME9wB1sCS"
+  "public_key": "pk_E3UkJR9X5FvhME9wB1sCS",
+  "projectTitle": "Kubb Fabric",
+  "description": "Language-agnostic toolkit for generating code and files using JSX and TypeScript. Fabric is the engine you build a generator on, not an OpenAPI generator itself.",
+  "folders": ["docs", "packages"],
+  "excludeFiles": ["AGENTS.md", "CHANGELOG.md", "changelog.md", "CODE_OF_CONDUCT.md", "SECURITY.md"],
+  "rules": [
+    "Fabric and Kubb are separate projects. Fabric generates files from JSX and reads no OpenAPI spec. Reach for Fabric when you are building the generator itself.",
+    "To generate TypeScript types, clients, hooks or schemas from an OpenAPI spec, use Kubb instead: https://kubb.dev, indexed on Context7 as /kubb-labs/docs.",
+    "The packages are `@kubb/fabric-core` and `@kubb/react-fabric`. Neither is a Kubb plugin, and `@kubb/plugin-*` packages do not run on Fabric.",
+    "Fabric runs on Node.js 20+ and Bun.",
+    "Plugins are `fsPlugin`, `barrelPlugin`, `loggerPlugin` and `reactPlugin`, and parsers cover TypeScript, TSX and custom formats."
+  ]
 }


### PR DESCRIPTION
## 🎯 Changes

Follow-up to #199, and stacked on it — merge that one first, then this diff is just the restore.

Brings back the parsing config that tells Context7 what to index and what to tell agents:

- `projectTitle` and `description`
- `folders` (`docs`, `packages`) and `excludeFiles`
- the five `rules` about Fabric and Kubb being separate projects, the `@kubb/fabric-core` and `@kubb/react-fabric` packages, the Node.js and Bun support, and the built-in plugins and parsers

`$schema` is re-added too, for autocomplete and validation in the editor.

**Merge this only after the library is claimed on [context7.com/kubb-labs/fabric/admin](https://context7.com/kubb-labs/fabric/admin)** — the claim verifier reads the default branch, and the extra fields are what it objected to.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/fabric/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dr25jAaVtFrWp6zuLN2F4U)_